### PR TITLE
Added keyword to parse-decimal-number to aid in signed number parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Examples:
 	(parse-decimal-number "-1234"
                           :start 0
                           :end 2
-						  :subseq-include-sign nil) => -12
+                          :subseq-include-sign nil) => -12
 
 ### Function: `round-half-away-from-zero`
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ below. The default value is in parentheses.
 The lambda list:
 
      (string &key (decimal-separator #\.) (positive-sign #\+)
-             (negative-sign #\-) (start 0) (end nil))
+             (negative-sign #\-) (start 0) (end nil) (subseq-include-sign t)
 
 Examine _string_ (or its substring from _start_ to _end_) for a
 decimal number. Assume that the decimal number is exact and return it as

--- a/README.md
+++ b/README.md
@@ -270,6 +270,12 @@ character which separates integer and fractional parts. All other
 characters are illegal. If these rules are not met a
 `decimal-parse-error` condition is signaled.
 
+_subseq-include-sign_ controls the effect of _start_ and _end_, such
+that if `T`, sign characters will be counted as part of any substring
+of _string_.  When `NIL` the sign is applied to the parsed number,
+but the magnitude of the parsed number will be the same as if it were
+unsigned.
+
 Examples:
 
     (parse-decimal-number "0.2")  => 1/5
@@ -282,6 +288,12 @@ Examples:
                           :negative-sign #\−)
     => -2469/200
 
+	(parse-decimal-number "-1234" :start 0 :end 2) => -1
+	(parse-decimal-number "1234" :start 0 :end 2) => 12
+	(parse-decimal-number "-1234"
+                          :start 0
+                          :end 2
+						  :subseq-include-sign nil) => -12
 
 ### Function: `round-half-away-from-zero`
 

--- a/decimals.lisp
+++ b/decimals.lisp
@@ -392,14 +392,17 @@ Examples:
 
   (setf string (string-trim " " string))
   (assert (plusp (length string)) (string) 'decimal-parse-error)
-  (let ((sign 1))
+  (let ((sign 1)
+	(sign-char? (char string 0)))
+    (when (char= sign-char? negative-sign)
+      (setf sign -1))
     (setf string
-	  (cond ((char= (char string 0) negative-sign)
-		 (setf sign -1)
-		 (subseq string 1 (if subseq-include-sign end (1+ end))))
-		((char= (char string 0) positive-sign)
-		 (subseq string 1 (if subseq-include-sign end (1+ end))))
-		(t (subseq string start end))))
+	  (if (or (char= sign-char? negative-sign)
+		  (char= sign-char? positive-sign))
+	      (if subseq-include-sign
+		  (subseq string (if (= 0 start) 1 start) end)
+		  (subseq string (1+ start) (when end (1+ end))))
+	      (subseq string start end)))
 
     (if (and (every (lambda (item)
 		      (or (digit-char-p item)

--- a/decimals.lisp
+++ b/decimals.lisp
@@ -402,8 +402,9 @@ Examples:
 	      (if subseq-include-sign
 		  (subseq string 1)
 		  (subseq string (1+ start) (when end (1+ end))))
-	      (unless subseq-include-sign
-		(subseq string start end))))
+	      (if subseq-include-sign
+		  string
+		  (subseq string start end))))
 
     (if (and (every (lambda (item)
 		      (or (digit-char-p item)

--- a/decimals.lisp
+++ b/decimals.lisp
@@ -362,8 +362,8 @@ couldn't parse a decimal number from string."))
                              (decimal-separator #\.)
                              (positive-sign #\+)
                              (negative-sign #\-)
-			     (start 0) (end nil)
-			     (subseq-include-sign t))
+                             (start 0) (end nil)
+                             (subseq-include-sign t))
 
   "Examine _string_ (or its substring from _start_ to _end_) for a
 decimal number. Assume that the decimal number is exact and return it as
@@ -390,10 +390,8 @@ Examples:
                           :negative-sign #\\−)
     => -2469/200"
 
-  (assert (plusp (length string)) (string) 'decimal-parse-error)
-
   (setf string (string-trim " " string))
-
+  (assert (plusp (length string)) (string) 'decimal-parse-error)
   (let ((sign 1))
     (setf string
 	  (cond ((char= (char string 0) negative-sign)

--- a/decimals.lisp
+++ b/decimals.lisp
@@ -390,19 +390,20 @@ Examples:
                           :negative-sign #\\−)
     => -2469/200"
 
+  (when subseq-include-sign
+    (setf string (subseq string start end)))
   (setf string (string-trim " " string))
   (assert (plusp (length string)) (string) 'decimal-parse-error)
-  (let ((sign 1)
-	(sign-char? (char string 0)))
-    (when (char= sign-char? negative-sign)
-      (setf sign -1))
+  (let* ((sign-char? (char string 0))
+	 (sign (if (char= sign-char? negative-sign) -1 1)))
     (setf string
 	  (if (or (char= sign-char? negative-sign)
 		  (char= sign-char? positive-sign))
 	      (if subseq-include-sign
-		  (subseq string (if (= 0 start) 1 start) end)
+		  (subseq string 1)
 		  (subseq string (1+ start) (when end (1+ end))))
-	      (subseq string start end)))
+	      (unless subseq-include-sign
+		(subseq string start end))))
 
     (if (and (every (lambda (item)
 		      (or (digit-char-p item)

--- a/decimals.lisp
+++ b/decimals.lisp
@@ -362,7 +362,8 @@ couldn't parse a decimal number from string."))
                              (decimal-separator #\.)
                              (positive-sign #\+)
                              (negative-sign #\-)
-                             (start 0) (end nil))
+			     (start 0) (end nil)
+			     (subseq-include-sign t))
 
   "Examine _string_ (or its substring from _start_ to _end_) for a
 decimal number. Assume that the decimal number is exact and return it as
@@ -389,31 +390,34 @@ Examples:
                           :negative-sign #\\−)
     => -2469/200"
 
-  (setf string (string-trim " " (subseq string start end)))
-  (if (not (plusp (length string)))
-      (error 'decimal-parse-error)
-      (let ((sign 1))
-        (cond ((char= (aref string 0) negative-sign)
-               (setf sign -1
-                     string (subseq string 1)))
-              ((char= (aref string 0) positive-sign)
-               (setf string (subseq string 1))))
+  (assert (plusp (length string)) (string) 'decimal-parse-error)
 
-        (if (and (every (lambda (item)
-                          (or (digit-char-p item)
-                              (char= item decimal-separator)))
-                        string)
-                 (some #'digit-char-p string)
-                 (<= 0 (count decimal-separator string) 1))
+  (setf string (string-trim " " string))
 
-            (let ((pos (position decimal-separator string)))
-              (* sign
-                 (+ (or (number-string-to-integer (subseq string 0 pos))
-                        0)
-                    (if pos
-                        (or (number-string-to-fractional
-                             (subseq string (1+ pos)))
-                            0)
-                        0))))
+  (let ((sign 1))
+    (setf string
+	  (cond ((char= (char string 0) negative-sign)
+		 (setf sign -1)
+		 (subseq string 1 (if subseq-include-sign end (1+ end))))
+		((char= (char string 0) positive-sign)
+		 (subseq string 1 (if subseq-include-sign end (1+ end))))
+		(t (subseq string start end))))
 
-            (error 'decimal-parse-error)))))
+    (if (and (every (lambda (item)
+		      (or (digit-char-p item)
+			  (char= item decimal-separator)))
+		    string)
+	     (some #'digit-char-p string)
+	     (<= 0 (count decimal-separator string) 1))
+
+	(let ((pos (position decimal-separator string)))
+	  (* sign
+	     (+ (or (number-string-to-integer (subseq string 0 pos))
+		    0)
+		(if pos
+		    (or (number-string-to-fractional
+			 (subseq string (1+ pos)))
+			0)
+		    0))))
+
+	(error 'decimal-parse-error))))


### PR DESCRIPTION
When using CL-DECIMALS I was getting an error while parsing signed numbers.    For instance:
`(parse-decimal-number "+12" :start 0 :end 1) => DECIMAL-PARSE-ERROR`.  This makes sense because the subseq is preformed before any other operations to parse the number and in this case the string becomes just "+", which isn't a number.

I added the :subseq-include-sign keyword, which defaults to T to keep existing behavior, but when nil, allows numbers to be subseq after discarding any spaces or a sign characters.
`(parse-decimal-number "12" :start 0 :end 1 :subseq-include-sign nil) => 1
(parse-decimal-number "+12" :start 0 :end 1 :subseq-include-sign nil) => 1
(parse-decimal-number "-12" :start 0 :end 1 :subseq-include-sign nil) => -1`

I'm not sure if you find this behavior useful, but I would.  Thanks again for releasing decimals.  It's a great library!